### PR TITLE
Active volume takeover on mount (stop -> detach -> force -> terminate)

### DIFF
--- a/.github/workflows/integration-env.yml
+++ b/.github/workflows/integration-env.yml
@@ -1,0 +1,73 @@
+name: Integration env (setup + teardown)
+
+on:
+  workflow_dispatch:
+    inputs:
+      hold_seconds:
+        description: "Seconds to keep the environment up before destroying"
+        type: string
+        default: "0"
+
+concurrency: integration-test
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TF_DIR: test/integration
+  AWS_REGION: ${{ secrets.AWS_TEST_REGION }}
+
+jobs:
+  env:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.5"
+
+      - name: Build plugin (arm64)
+        run: make tar-arm64 COMMIT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-7)
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.OIDC_TEST_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform apply
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          terraform init -input=false
+          terraform apply -auto-approve -input=false \
+            -var "aws_region=${{ env.AWS_REGION }}" \
+            -var "plugin_tarball_path=${{ github.workspace }}/polarity-ecs-ebs-plugin.arm64.tar.gz"
+
+      - name: Wait for service to stabilize
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          aws ecs wait services-stable \
+            --cluster "$(terraform output -raw cluster_name)" \
+            --services "$(terraform output -raw service_name)"
+
+      - name: Hold environment
+        if: ${{ inputs.hold_seconds != '0' }}
+        run: sleep "${{ inputs.hold_seconds }}"
+
+      - name: Terraform destroy
+        if: always()
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          terraform destroy -auto-approve -input=false \
+            -var "aws_region=${{ env.AWS_REGION }}" \
+            -var "plugin_tarball_path=${{ github.workspace }}/polarity-ecs-ebs-plugin.arm64.tar.gz"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,80 @@
+name: Integration test
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment_maximum_percent:
+        description: "ECS service deployment_maximum_percent"
+        type: choice
+        options: ["200", "100"]
+        default: "200"
+      grant_stop_task:
+        description: "Grant ecs:StopTask to the instance role (off = test fail-safe)"
+        type: boolean
+        default: true
+
+concurrency: integration-test
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TF_DIR: test/integration
+  AWS_REGION: ${{ secrets.AWS_TEST_REGION }}
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.5"
+
+      - name: Build plugin (arm64)
+        run: make tar-arm64 COMMIT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-7)
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.OIDC_TEST_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install session-manager-plugin
+        run: |
+          curl -s "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb" -o smp.deb
+          sudo dpkg -i smp.deb
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform apply
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          terraform init -input=false
+          terraform apply -auto-approve -input=false \
+            -var "aws_region=${{ env.AWS_REGION }}" \
+            -var "plugin_tarball_path=${{ github.workspace }}/polarity-ecs-ebs-plugin.arm64.tar.gz" \
+            -var "deployment_maximum_percent=${{ inputs.deployment_maximum_percent || '200' }}" \
+            -var "grant_stop_task=${{ inputs.grant_stop_task || 'true' }}"
+
+      - name: Run scenarios
+        working-directory: ${{ env.TF_DIR }}
+        run: ./run-tests.sh
+
+      - name: Terraform destroy
+        if: always()
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          terraform destroy -auto-approve -input=false \
+            -var "aws_region=${{ env.AWS_REGION }}" \
+            -var "plugin_tarball_path=${{ github.workspace }}/polarity-ecs-ebs-plugin.arm64.tar.gz" \
+            -var "deployment_maximum_percent=${{ inputs.deployment_maximum_percent || '200' }}" \
+            -var "grant_stop_task=${{ inputs.grant_stop_task || 'true' }}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build/
 *.tar.gz
 *.sock
 dist/
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM alpine:latest AS rootfs
+# Pinned: newer xfsprogs (alpine:latest) defaults mkfs.xfs to XFS incompat features
+# (parent pointers, exchange-range) that older LTS kernels (e.g. AL2023 6.1) refuse to
+# mount. 3.20 ships xfsprogs 6.8, which keeps those off.
+FROM alpine:3.20 AS rootfs
 
 RUN apk add --no-cache lsblk xfsprogs ca-certificates tzdata && \
     update-ca-certificates && \

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ IAM Policy example. This should be applied to the IAM Role of the EC2 instances 
             "Effect": "Allow",
             "Resource": "*"
         },
-				{
+        {
             "Sid": "DockerPluginWrite",
             "Action": [
                 "ec2:DetachVolume",
@@ -117,14 +117,30 @@ IAM Policy example. This should be applied to the IAM Role of the EC2 instances 
             ],
             "Effect": "Allow",
             "Resource": "<volume_arn>"
+        },
+        {
+            "Sid": "DockerPluginTakeover",
+            "Action": [
+                "ecs:StopTask"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
         }
     ]
 }
 ```
 
+> `ecs:StopTask` is needed for the volume takeover (see Notes). Without it the plugin stays on the legacy non-force path and never force-detaches a possibly-live volume.
+
 
 ## Notes
 When the task dies or is terminated by ECS, the volume is NOT automatically detached from the EC2: this is intentional to spin up a new instance of the container faster in case of failure or ECS service update.
+
+### Volume takeover on mount
+
+`Mount` gates container startup, so the plugin is the single point of control over who touches the volume. This makes `deployment_maximum_percent = 200` safe (ECS may schedule a second task, but it can't write until the plugin lets it) while staying compatible with `100`.
+
+On `Mount`, before attaching locally, the plugin stops every other task whose container may still be live on the volume (`lastStatus` RUNNING/DEACTIVATING/STOPPING) and waits for `STOPPED`. The task being mounted is pre-`RUNNING`, so it is never stopped. It then detaches the volume from the instance that holds it — non-force if that instance is healthy, force if it's unreachable — and waits for the block device to be readable before mounting (the `/dev` node can appear before the kernel has the device online). If even the force-detach can't free the volume, the plugin fails the mount and lets ECS retry; terminating the stuck instance is left to a human. Assumes `desired_count = 1`.
 
 ## Development instructions
 

--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -28,6 +28,10 @@ type MountResponse struct {
 var Debug string = "false"
 var CommitHash string = "unknown"
 
+// Gates the last-resort "terminate the holder" fallback. Off: automating instance
+// termination from a volume driver is too broad a blast radius, so a human does it.
+var canTerminateInstances = false
+
 func main() {
 	if Debug == "true" {
 		logFile, err := os.OpenFile("/logging/polarity-ecs-ebs.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
@@ -156,36 +160,114 @@ func main() {
 			return
 		}
 
-		checkVolRes, checkVolErr := internal.CheckForTasksWithVolumeInUse(req.Name, meta.Region, meta.AvailabilityZone)
-		switch checkVolRes {
-		case internal.OK:
-			log.Printf("Volume %s is not in use by any ECS tasks", req.Name)
-		case internal.ProcessingError:
-			response := MountResponse{Err: fmt.Sprintf("Error checking volume usage: %v", checkVolErr), MountPoint: ""}
-			json.NewEncoder(w).Encode(response)
-			return
-		default:
-			response := MountResponse{Err: fmt.Sprintf("Volume %s is in use by ECS tasks", req.Name), MountPoint: ""}
+		checkResult := internal.CheckForTasksWithVolumeInUse(req.Name, meta.Region, meta.AvailabilityZone)
+		if checkResult.Status == internal.ProcessingError {
+			response := MountResponse{Err: fmt.Sprintf("Error checking volume usage: %v", checkResult.Err), MountPoint: ""}
 			json.NewEncoder(w).Encode(response)
 			return
 		}
 
-		// attach the volume using aws sdk
-		if vol.State == types.VolumeStateInUse && vol.Attachments[0].InstanceId != nil && *vol.Attachments[0].InstanceId != meta.InstanceID {
-			log.Printf("Volume %s is in-use by another instance (%s), detaching...", req.Name, *vol.Attachments[0].InstanceId)
+		// Stop every other task whose container may still be live on the volume before
+		// mounting it here.
+		forceDetachNeeded := false
+		stopNotPermitted := false
+		candidates := internal.StopCandidates(checkResult.Tasks)
+		if len(candidates) > 0 {
+			log.Printf("Volume %s: %d live task(s) using it, stopping them before takeover", req.Name, len(candidates))
 
-			_, err := internal.DetachVolume(r.Context(), client, req.Name, *vol.Attachments[0].InstanceId)
+			for _, task := range candidates {
+				log.Printf("Stopping conflicting task %s (instance: %s, last: %s)", task.TaskArn, task.InstanceID, task.Status)
+				stopErr := internal.StopTask(meta.Region, task.ClusterArn, task.TaskArn)
+				if stopErr == nil {
+					continue
+				}
+				log.Printf("StopTask failed for %s: %v", task.TaskArn, stopErr)
+
+				// No ecs:StopTask permission: stay on the legacy non-force path and never
+				// force-detach a possibly-live volume (same as the old plugin).
+				if internal.IsAuthorizationError(stopErr) {
+					log.Printf("StopTask not permitted (grant ecs:StopTask to enable takeover) — staying on non-force detach")
+					stopNotPermitted = true
+				}
+
+				// Can't stop a live task on our own instance: unsafe to take over.
+				if task.InstanceID == meta.InstanceID {
+					response := MountResponse{Err: fmt.Sprintf("Cannot mount: local task %s (last=%s) could not be stopped: %v", task.TaskArn, task.Status, stopErr), MountPoint: ""}
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				// Stop failed on another, unreachable instance → force detach, but only
+				// if we actually have the permission to stop (otherwise stay legacy).
+				if !stopNotPermitted {
+					forceDetachNeeded = true
+				}
+			}
+
+			vol, err = internal.DescribeVolume(r.Context(), client, req.Name)
 			if err != nil {
-				response := MountResponse{Err: fmt.Sprintf("Failed to detach volume: %v", err), MountPoint: ""}
+				response := MountResponse{Err: fmt.Sprintf("Failed to describe volume after stop: %v", err), MountPoint: ""}
+				json.NewEncoder(w).Encode(response)
+				return
+			}
+		}
+
+		// Detach the volume from whichever instance still holds it: non-force if the
+		// holder was stopped cleanly, force if it's unreachable, terminate as last resort.
+		if vol.State == types.VolumeStateInUse && len(vol.Attachments) > 0 && vol.Attachments[0].InstanceId != nil && *vol.Attachments[0].InstanceId != meta.InstanceID {
+			attachedInstance := *vol.Attachments[0].InstanceId
+			detached := false
+
+			if !forceDetachNeeded {
+				log.Printf("Volume %s in-use by %s, attempting non-force detach...", req.Name, attachedInstance)
+				if _, derr := internal.DetachVolume(r.Context(), client, req.Name, attachedInstance); derr != nil {
+					log.Printf("Non-force detach call failed: %v", derr)
+				} else if _, werr := internal.WaitVolumeTimeout(r.Context(), client, req.Name, types.VolumeStateAvailable, 30*time.Second); werr != nil {
+					log.Printf("Volume not available after non-force detach: %v — escalating to force", werr)
+				} else {
+					detached = true
+				}
+			}
+
+			// Without ecs:StopTask we stay on the legacy path: never force-detach a
+			// possibly-live volume. Fail here; ECS retries until the old task is gone.
+			if !detached && stopNotPermitted {
+				response := MountResponse{Err: fmt.Sprintf("Volume %s not released by non-force detach; force-detach disabled without ecs:StopTask", req.Name), MountPoint: ""}
 				json.NewEncoder(w).Encode(response)
 				return
 			}
 
-			log.Printf("Successfully detached volume %s, waiting to be available", req.Name)
-			// NOTE: This overrides the previous volume state check
-			vol, err = internal.WaitVolume(r.Context(), client, req.Name, types.VolumeStateAvailable)
+			if !detached {
+				log.Printf("Force-detaching volume %s from %s...", req.Name, attachedInstance)
+				if _, derr := internal.DetachVolumeWithForce(r.Context(), client, req.Name, attachedInstance, true); derr != nil {
+					log.Printf("Force detach call failed: %v", derr)
+				}
+				if _, werr := internal.WaitVolumeTimeout(r.Context(), client, req.Name, types.VolumeStateAvailable, 60*time.Second); werr != nil {
+					// Force-detach didn't free the volume. Terminating the holder is a last
+					// resort gated behind canTerminateInstances (off: too broad a blast radius
+					// to automate); otherwise fail and let ECS retry / a human step in.
+					if !canTerminateInstances {
+						response := MountResponse{Err: fmt.Sprintf("Volume %s still not available after force detach: %v (manual intervention required on %s)", req.Name, werr, attachedInstance), MountPoint: ""}
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					log.Printf("Volume still not available after force detach: %v — terminating instance %s", werr, attachedInstance)
+					if termErr := internal.TerminateInstance(meta.Region, attachedInstance); termErr != nil {
+						response := MountResponse{Err: fmt.Sprintf("All recovery attempts failed: force-detach err=%v, terminate err=%v", werr, termErr), MountPoint: ""}
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					if _, werr2 := internal.WaitVolume(r.Context(), client, req.Name, types.VolumeStateAvailable); werr2 != nil {
+						response := MountResponse{Err: fmt.Sprintf("Volume not available after terminating instance %s: %v", attachedInstance, werr2), MountPoint: ""}
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+				}
+			}
+
+			vol, err = internal.DescribeVolume(r.Context(), client, req.Name)
 			if err != nil {
-				response := MountResponse{Err: fmt.Sprintf("Failed to wait for volume to be available: %v", err), MountPoint: ""}
+				response := MountResponse{Err: fmt.Sprintf("Failed to describe volume after detach: %v", err), MountPoint: ""}
 				json.NewEncoder(w).Encode(response)
 				return
 			}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.30.3
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.241.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.63.0
+	github.com/aws/smithy-go v1.22.5
 )
 
 require (
@@ -20,5 +21,4 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.27.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.32.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.36.0 // indirect
-	github.com/aws/smithy-go v1.22.5 // indirect
 )

--- a/internal/checkecs.go
+++ b/internal/checkecs.go
@@ -2,15 +2,18 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/smithy-go"
 )
 
 type Status int
@@ -21,13 +24,27 @@ const (
 	VolumeInUseError
 )
 
+type TaskInfo struct {
+	TaskArn       string
+	ClusterArn    string
+	Status        string
+	DesiredStatus string
+	InstanceID    string
+}
+
+type CheckResult struct {
+	Status Status
+	Err    error
+	Tasks  []TaskInfo
+}
+
 // Check single cluster
-func checkCluster(ctx context.Context, cfg aws.Config, clusterArn, targetAZ string, volumeFound *int, mu *sync.Mutex, wg *sync.WaitGroup, volumeToCheck string) {
+func checkCluster(ctx context.Context, cfg aws.Config, clusterArn, targetAZ string, mu *sync.Mutex, wg *sync.WaitGroup, volumeToCheck string, tasks *[]TaskInfo) {
 	defer wg.Done()
 
 	ecsClient := ecs.NewFromConfig(cfg)
 	ec2Client := ec2.NewFromConfig(cfg)
-	clusterName := *aws.String(clusterArn[strings.LastIndex(clusterArn, "/")+1:])
+	clusterName := clusterArn[strings.LastIndex(clusterArn, "/")+1:]
 
 	// 1. List all container instances in cluster
 	log.Printf("Checking cluster %s for volume %s in AZ %s", clusterName, volumeToCheck, targetAZ)
@@ -45,7 +62,7 @@ func checkCluster(ctx context.Context, cfg aws.Config, clusterArn, targetAZ stri
 		return
 	}
 
-	// 2. Describe container instances to get EC2 IDsq
+	// 2. Describe container instances to get EC2 IDs
 	describedCIs, err := ecsClient.DescribeContainerInstances(ctx, &ecs.DescribeContainerInstancesInput{Cluster: &clusterName, ContainerInstances: ciArns})
 	if err != nil {
 		log.Printf("error describing instances for %s: %v", clusterName, err)
@@ -53,9 +70,11 @@ func checkCluster(ctx context.Context, cfg aws.Config, clusterArn, targetAZ stri
 	}
 
 	ec2IdToCiArn := make(map[string]string)
+	ciArnToEc2Id := make(map[string]string)
 	var ec2Ids []string
 	for _, ci := range describedCIs.ContainerInstances {
 		ec2IdToCiArn[*ci.Ec2InstanceId] = *ci.ContainerInstanceArn
+		ciArnToEc2Id[*ci.ContainerInstanceArn] = *ci.Ec2InstanceId
 		ec2Ids = append(ec2Ids, *ci.Ec2InstanceId)
 	}
 
@@ -102,8 +121,10 @@ func checkCluster(ctx context.Context, cfg aws.Config, clusterArn, targetAZ stri
 
 	taskDefsToInspect := make(map[string]bool)
 	for _, task := range describedTasks.Tasks {
-		if _, ok := ciArnsInAZ[*task.ContainerInstanceArn]; ok {
-			taskDefsToInspect[*task.TaskDefinitionArn] = true
+		if task.ContainerInstanceArn != nil {
+			if _, ok := ciArnsInAZ[*task.ContainerInstanceArn]; ok {
+				taskDefsToInspect[*task.TaskDefinitionArn] = true
+			}
 		}
 	}
 
@@ -131,34 +152,35 @@ func checkCluster(ctx context.Context, cfg aws.Config, clusterArn, targetAZ stri
 
 	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle-explanation.html
 	stillRunningTaskState := map[string]struct{}{
-		"RUNNING":   {},
-		"PENDING":   {},
-		"PROVISIONING":   {},
+		"RUNNING":      {},
+		"PENDING":      {},
+		"PROVISIONING": {},
 		"ACTIVATING":   {},
-		"DEACTIVATING":   {},
-		"STOPPING":   {},
-		// "DEPROVISIONING":   {}, // I think this can be ignored
+		"DEACTIVATING": {},
+		"STOPPING":     {},
 	}
 
 	for _, taskDefArn := range taskDefArnsToCheck {
-		// At the start of each iteration, check if a task that uses the volume was already found
-		mu.Lock()
-		if *volumeFound > 1 {
-			mu.Unlock()
-			return
-		}
-		mu.Unlock()
 		for _, task := range describedTasks.Tasks {
 			if *task.TaskDefinitionArn == taskDefArn {
 				if _, ok := stillRunningTaskState[*task.LastStatus]; ok {
-					// If the task is still in one of the state above, we can consider the volume in use
-					mu.Lock()
-					*volumeFound += 1
-					log.Printf("Volume '%s' is in use by task %s in cluster %s", volumeToCheck, *task.TaskArn, clusterName)
-					if *volumeFound > 1 {
-						mu.Unlock()
-						return
+					instanceID := ""
+					if task.ContainerInstanceArn != nil {
+						instanceID = ciArnToEc2Id[*task.ContainerInstanceArn]
 					}
+					desiredStatus := ""
+					if task.DesiredStatus != nil {
+						desiredStatus = *task.DesiredStatus
+					}
+					mu.Lock()
+					*tasks = append(*tasks, TaskInfo{
+						TaskArn:       *task.TaskArn,
+						ClusterArn:    clusterArn,
+						Status:        *task.LastStatus,
+						DesiredStatus: desiredStatus,
+						InstanceID:    instanceID,
+					})
+					log.Printf("Volume '%s' is in use by task %s (last: %s, desired: %s, instance: %s) in cluster %s", volumeToCheck, *task.TaskArn, *task.LastStatus, desiredStatus, instanceID, clusterName)
 					mu.Unlock()
 				}
 			}
@@ -166,13 +188,15 @@ func checkCluster(ctx context.Context, cfg aws.Config, clusterArn, targetAZ stri
 	}
 }
 
-func CheckForTasksWithVolumeInUse(volumeToCheck string, region string, availabilityZone string) (Status, error) {
+// CheckForTasksWithVolumeInUse checks all clusters for tasks using the given volume.
+// Returns the list of tasks found so the caller can decide what to do.
+func CheckForTasksWithVolumeInUse(volumeToCheck string, region string, availabilityZone string) CheckResult {
 	log.Println("Starting check for tasks using volume: ", volumeToCheck)
 
 	ctx := context.Background()
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
-		return ProcessingError, fmt.Errorf("error while creating AWS configuration: %v", err)
+		return CheckResult{Status: ProcessingError, Err: fmt.Errorf("error while creating AWS configuration: %v", err)}
 	}
 
 	ecsClient := ecs.NewFromConfig(cfg)
@@ -180,29 +204,145 @@ func CheckForTasksWithVolumeInUse(volumeToCheck string, region string, availabil
 	log.Println("List all clusters in AZ...")
 	clustersOutput, err := ecsClient.ListClusters(ctx, &ecs.ListClustersInput{})
 	if err != nil {
-		return ProcessingError, fmt.Errorf("cannot list clusters: %v", err)
+		return CheckResult{Status: ProcessingError, Err: fmt.Errorf("cannot list clusters: %v", err)}
 	}
 
 	if len(clustersOutput.ClusterArns) == 0 {
 		log.Println("No clusters found in this AZ.")
-		return OK, nil
+		return CheckResult{Status: OK}
 	}
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	volumeFound := 0
+	var tasks []TaskInfo
 
 	// Check each cluster concurrently
 	for _, clusterArn := range clustersOutput.ClusterArns {
 		wg.Add(1)
-		go checkCluster(ctx, cfg, clusterArn, availabilityZone, &volumeFound, &mu, &wg, volumeToCheck)
+		go checkCluster(ctx, cfg, clusterArn, availabilityZone, &mu, &wg, volumeToCheck, &tasks)
 	}
 
-	wg.Wait() // Wait for all checks to finish
+	wg.Wait()
 
-	if volumeFound > 1 {
-		return VolumeInUseError, fmt.Errorf("volume '%s' is currently in use by task", volumeToCheck)
+	if len(tasks) == 0 {
+		return CheckResult{Status: OK, Tasks: nil}
 	}
 
-	return OK, nil
+	return CheckResult{Status: VolumeInUseError, Tasks: tasks, Err: fmt.Errorf("volume '%s' is in use by %d task(s)", volumeToCheck, len(tasks))}
+}
+
+// StopTask attempts to stop an ECS task. Returns nil on success.
+func StopTask(region string, clusterArn string, taskArn string) error {
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	ecsClient := ecs.NewFromConfig(cfg)
+
+	clusterName := clusterArn[strings.LastIndex(clusterArn, "/")+1:]
+
+	log.Printf("Stopping task %s in cluster %s", taskArn, clusterName)
+	_, err = ecsClient.StopTask(ctx, &ecs.StopTaskInput{
+		Cluster: &clusterName,
+		Task:    &taskArn,
+		Reason:  aws.String("polarity-ecs-ebs-plugin: volume takeover for new task"),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to stop task %s: %w", taskArn, err)
+	}
+
+	log.Printf("StopTask issued for %s, waiting for STOPPED state...", taskArn)
+
+	// Wait for the task to reach STOPPED state (poll every 2s, max 60s)
+	for i := 0; i < 30; i++ {
+		time.Sleep(2 * time.Second)
+
+		describeOutput, err := ecsClient.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+			Cluster: &clusterName,
+			Tasks:   []string{taskArn},
+		})
+		if err != nil {
+			log.Printf("Warning: failed to describe task %s: %v", taskArn, err)
+			continue
+		}
+
+		if len(describeOutput.Tasks) > 0 {
+			status := describeOutput.Tasks[0].LastStatus
+			if status != nil && (*status == "STOPPED" || *status == "DEPROVISIONING") {
+				log.Printf("Task %s is now %s", taskArn, *status)
+				return nil
+			}
+			log.Printf("Task %s is still in state %s, waiting...", taskArn, *status)
+		}
+
+		// Task not found = already gone
+		if len(describeOutput.Failures) > 0 {
+			for _, f := range describeOutput.Failures {
+				if f.Reason != nil && *f.Reason == "MISSING" {
+					log.Printf("Task %s no longer exists (MISSING), treating as stopped", taskArn)
+					return nil
+				}
+			}
+		}
+	}
+
+	return fmt.Errorf("task %s did not reach STOPPED state within 60s", taskArn)
+}
+
+// TerminateInstance terminates an EC2 instance. Last-resort fallback, gated off by
+// default in the caller (see canTerminateInstances).
+func TerminateInstance(region string, instanceID string) error {
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	ec2Client := ec2.NewFromConfig(cfg)
+
+	log.Printf("TERMINATING instance %s as last resort for volume recovery", instanceID)
+	_, err = ec2Client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to terminate instance %s: %w", instanceID, err)
+	}
+
+	log.Printf("TerminateInstances issued for %s", instanceID)
+	return nil
+}
+
+// lastStatus values where a task's container may still be live on the volume. A task
+// being mounted is pre-RUNNING, so it is never matched.
+var liveContainerStates = map[string]struct{}{
+	"RUNNING":      {},
+	"DEACTIVATING": {},
+	"STOPPING":     {},
+}
+
+// StopCandidates returns the other tasks whose container may still be live on the
+// volume and must be stopped before we can mount it here.
+func StopCandidates(tasks []TaskInfo) []TaskInfo {
+	var candidates []TaskInfo
+	for _, t := range tasks {
+		if _, live := liveContainerStates[t.Status]; live {
+			candidates = append(candidates, t)
+		}
+	}
+	return candidates
+}
+
+// IsAuthorizationError reports whether err is an AWS authorization failure (e.g. a
+// missing IAM permission) rather than a runtime/unreachable-instance failure.
+func IsAuthorizationError(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "MissingAuthenticationToken":
+			return true
+		}
+	}
+	return false
 }

--- a/internal/mount.go
+++ b/internal/mount.go
@@ -95,10 +95,44 @@ func getMountpoint(device string) (string, error) {
 	return "", nil
 }
 
+// waitForBlockDevice blocks until the device is readable: after an attach the /dev
+// node can appear before the kernel has brought the device online.
+func waitForBlockDevice(device string, timeout time.Duration) error {
+	if !strings.HasPrefix(device, "/dev") {
+		device = "/dev/" + device
+	}
+
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		f, err := os.OpenFile(device, os.O_RDONLY, 0)
+		if err != nil {
+			lastErr = err
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		buf := make([]byte, 512)
+		_, rerr := f.Read(buf)
+		f.Close()
+		if rerr == nil {
+			log.Printf("Device %s is readable and ready", device)
+			return nil
+		}
+		lastErr = rerr
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return fmt.Errorf("device %s not readable within %s: %v", device, timeout, lastErr)
+}
+
 func Mount(volumeID string) error {
 	device, err := FindDeviceByVolumeID(volumeID)
 	if err != nil {
 		return fmt.Errorf("error finding device: %v", err)
+	}
+
+	if err := waitForBlockDevice(device, 20*time.Second); err != nil {
+		return fmt.Errorf("device not ready after attach: %v", err)
 	}
 
 	filesystem, err := GetFilesystem(device)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -67,18 +67,32 @@ func AttachVolume(ctx context.Context, client *ec2.Client, volumeID string, inst
 	return ebs, nil
 }
 
-// detachVolume detaches a volume from the EC2 instance.
+// DetachVolume detaches a volume from the EC2 instance.
 func DetachVolume(ctx context.Context, client *ec2.Client, volumeID, instanceID string) (*ec2.DetachVolumeOutput, error) {
+	return DetachVolumeWithForce(ctx, client, volumeID, instanceID, false)
+}
+
+// DetachVolumeWithForce detaches a volume; force=true works even if the instance is unreachable.
+func DetachVolumeWithForce(ctx context.Context, client *ec2.Client, volumeID, instanceID string, force bool) (*ec2.DetachVolumeOutput, error) {
 	commandDetach := &ec2.DetachVolumeInput{
 		InstanceId: aws.String(instanceID),
 		VolumeId:   aws.String(volumeID),
+		Force:      aws.Bool(force),
 	}
 	ebs, err := client.DetachVolume(ctx, commandDetach)
 	if err != nil {
-		return nil, fmt.Errorf("failed to detach volume: %w", err)
+		return nil, fmt.Errorf("failed to detach volume (force=%v): %w", force, err)
 	}
 
 	return ebs, nil
+}
+
+// WaitVolumeTimeout is WaitVolume bounded by a timeout, so a detach against an
+// unreachable instance (accepted by AWS but never completing) doesn't hang forever.
+func WaitVolumeTimeout(ctx context.Context, client *ec2.Client, volumeID string, state types.VolumeState, timeout time.Duration) (*types.Volume, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WaitVolume(ctx, client, volumeID, state)
 }
 
 // waitVolume waits for a volume to reach a specific state.

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,57 @@
+# Integration test
+
+Stands up a throwaway environment (VPC + public subnet, ECS cluster, ASG running the
+plugin build under test, an EBS volume and a MongoDB service that mounts it) and drives
+the plugin through its failure modes.
+
+Run it from GitHub Actions: **Actions → Integration test → Run workflow**. It builds the
+plugin, uploads it to S3, `terraform apply`, runs the scenarios, then always destroys.
+
+## Auth & required config
+
+The workflows authenticate to AWS via **GitHub OIDC** (no long-lived keys) using
+dedicated test secrets, kept separate from the release pipeline.
+
+| Repo secret | Purpose |
+|-------------|---------|
+| `OIDC_TEST_ROLE_ARN` | Role assumed via OIDC in the sandbox account (must allow the resources in `main.tf`) |
+| `AWS_TEST_REGION` | Region for the test environment |
+
+Everything else is ephemeral: Terraform creates a throwaway S3 bucket, uploads the built
+plugin tarball to it, and destroys it on teardown. No pre-existing bucket needed.
+
+## Workflow inputs
+
+- `deployment_maximum_percent` — `200` (fix active) or `100`.
+- `grant_stop_task` — grant `ecs:StopTask` to the instance role. Set **false** to verify
+  the fail-safe: without the permission the plugin must never force-detach a live volume.
+
+## Scenarios
+
+Both scenarios assert one hard invariant — the volume is recovered and the data survives.
+The escalation path taken (clean detach vs force-detach) is the expectation for the kernel
+state; an unexpected path emits a non-fatal `::warning::` with diagnostics instead of failing.
+
+| Scenario | Asserts |
+|----------|---------|
+| baseline | plugin mounts, sentinel written/read on the volume |
+| healthy handover (redeploy) | data survives the volume handover; a force-detach here is unexpected (warns) |
+| wedged holder | the holder's kernel is sysrq-panicked (the 2026-07-15 incident); ECS drains it so the plugin walks StopTask → non-force → force-detach; recovers on the other instance with data intact, force-detach expected |
+
+Assertions come from a sentinel file on the EBS volume (data integrity) and the plugin's
+docker journal on the host (whether a force-detach happened) — read via SSM Run Command,
+which is headless, unlike `ecs execute-command`.
+
+## Local
+
+The environment runs on arm64 (t4g) instances, so the plugin is built arm64 and the
+workflow uses a native ARM runner (`ubuntu-24.04-arm`) — no QEMU. The plugin build arch
+must always match `instance_type`.
+
+```sh
+make -C ../.. tar-arm64                        # build the plugin tarball (arm64)
+terraform init
+terraform apply -var plugin_tarball_path=../../polarity-ecs-ebs-plugin.arm64.tar.gz
+./run-tests.sh
+terraform destroy -var plugin_tarball_path=../../polarity-ecs-ebs-plugin.arm64.tar.gz
+```

--- a/test/integration/main.tf
+++ b/test/integration/main.tf
@@ -1,0 +1,467 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      Project   = "ecs-ebs-plugin-integration-test"
+      ManagedBy = "terraform"
+    }
+  }
+}
+
+
+### Variables ###
+
+variable "aws_region" {
+  type    = string
+  default = "eu-west-1"
+}
+
+variable "name_prefix" {
+  type    = string
+  default = "ebs-plugin-it"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.99.0.0/16"
+}
+
+variable "subnet_cidr" {
+  type    = string
+  default = "10.99.1.0/24"
+}
+
+# arm64 (Graviton). Must match the plugin build arch in the workflow.
+variable "instance_type" {
+  type    = string
+  default = "t4g.small"
+}
+
+variable "desired_instances" {
+  type    = number
+  default = 2
+}
+
+# Local path to the built plugin tarball; uploaded to an ephemeral bucket by TF.
+variable "plugin_tarball_path" {
+  type = string
+}
+
+variable "mongo_image" {
+  type    = string
+  default = "mongo:7"
+}
+
+variable "deployment_maximum_percent" {
+  type    = number
+  default = 200
+}
+
+# Toggle off to test the fail-safe fallback (no force-detach without ecs:StopTask).
+variable "grant_stop_task" {
+  type    = bool
+  default = true
+}
+
+### Data Sources ###
+
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_ssm_parameter" "ecs_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id"
+}
+
+locals {
+  az            = data.aws_availability_zones.available.names[0]
+  instance_attr = "ebsPluginIt"
+}
+
+
+### Plugin Artifact Bucket (ephemeral) ###
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+resource "aws_s3_bucket" "plugin" {
+  bucket        = "${var.name_prefix}-${random_id.suffix.hex}"
+  force_destroy = true
+  tags          = { Name = var.name_prefix }
+}
+
+resource "aws_s3_object" "plugin" {
+  bucket = aws_s3_bucket.plugin.id
+  key    = "plugin.tar.gz"
+  source = var.plugin_tarball_path
+  etag   = filemd5(var.plugin_tarball_path)
+}
+
+
+### VPC (single public subnet, no NAT) ###
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags                 = { Name = var.name_prefix }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = { Name = var.name_prefix }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.subnet_cidr
+  availability_zone       = local.az
+  map_public_ip_on_launch = true
+  tags                    = { Name = "${var.name_prefix}-public" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+  tags = { Name = "${var.name_prefix}-public" }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+
+### Security Group ###
+
+resource "aws_security_group" "instance" {
+  name        = "${var.name_prefix}-instance"
+  description = "ECS instances"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port   = 27017
+    to_port     = 27017
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = { Name = "${var.name_prefix}-instance" }
+}
+
+
+### Instance IAM Role ###
+
+resource "aws_iam_role" "instance" {
+  name = "${var.name_prefix}-instance"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "plugin_base" {
+  name = "${var.name_prefix}-plugin-base"
+  role = aws_iam_role.instance.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "VolumeOps"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeVolumes",
+          "ec2:DescribeInstances",
+          "ec2:DescribeTags",
+          "ec2:CreateTags",
+          "ec2:AttachVolume",
+          "ec2:DetachVolume"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "EcsRead"
+        Effect = "Allow"
+        Action = [
+          "ecs:ListClusters",
+          "ecs:ListContainerInstances",
+          "ecs:DescribeContainerInstances",
+          "ecs:ListTasks",
+          "ecs:DescribeTasks",
+          "ecs:DescribeTaskDefinition"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid      = "PluginDownload"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:ListBucket"]
+        Resource = [aws_s3_bucket.plugin.arn, "${aws_s3_bucket.plugin.arn}/*"]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "plugin_stop_task" {
+  count = var.grant_stop_task ? 1 : 0
+  name  = "${var.name_prefix}-plugin-stop-task"
+  role  = aws_iam_role.instance.name
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{ Sid = "StopTask", Effect = "Allow", Action = ["ecs:StopTask"], Resource = "*" }]
+  })
+}
+
+resource "aws_iam_instance_profile" "instance" {
+  name = "${var.name_prefix}-instance"
+  role = aws_iam_role.instance.name
+}
+
+
+### Launch Template + ASG ###
+
+resource "aws_launch_template" "this" {
+  name          = var.name_prefix
+  image_id      = data.aws_ssm_parameter.ecs_ami.value
+  instance_type = var.instance_type
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.instance.name
+  }
+
+  vpc_security_group_ids = [aws_security_group.instance.id]
+
+  user_data = base64encode(<<-EOF
+    #!/bin/bash
+    set -euxo pipefail
+    dnf install -y nvme-cli jq
+
+    cat >> /etc/ecs/ecs.config <<CFG
+    ECS_CLUSTER=${aws_ecs_cluster.this.name}
+    ECS_CONTAINER_STOP_TIMEOUT=10s
+    ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=1m
+    ECS_INSTANCE_ATTRIBUTES={"${local.instance_attr}":"true"}
+    CFG
+
+    # Install the plugin build under test
+    mkdir -p /tmp/plugin
+    aws s3 cp s3://${aws_s3_bucket.plugin.id}/${aws_s3_object.plugin.key} /tmp/plugin/plugin.tar.gz --region ${var.aws_region}
+    tar -xzf /tmp/plugin/plugin.tar.gz -C /tmp/plugin
+    docker plugin create polarity-ecs-ebs-plugin /tmp/plugin
+    docker plugin enable polarity-ecs-ebs-plugin
+    rm -rf /tmp/plugin
+    EOF
+  )
+
+  tag_specifications {
+    resource_type = "instance"
+    tags          = { Name = var.name_prefix }
+  }
+}
+
+resource "aws_autoscaling_group" "this" {
+  name                  = var.name_prefix
+  min_size              = 1
+  max_size              = var.desired_instances + 1
+  desired_capacity      = var.desired_instances
+  vpc_zone_identifier   = [aws_subnet.public.id]
+  health_check_type     = "EC2"
+  protect_from_scale_in = false
+
+  launch_template {
+    id      = aws_launch_template.this.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = var.name_prefix
+    propagate_at_launch = true
+  }
+}
+
+
+### ECS Cluster ###
+
+resource "aws_ecs_cluster" "this" {
+  name = var.name_prefix
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/${var.name_prefix}"
+  retention_in_days = 1
+}
+
+
+### Task Roles ###
+
+resource "aws_iam_role" "task_execution" {
+  name = "${var.name_prefix}-task-execution"
+  assume_role_policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{ Effect = "Allow", Principal = { Service = "ecs-tasks.amazonaws.com" }, Action = "sts:AssumeRole" }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task" {
+  name = "${var.name_prefix}-task"
+  assume_role_policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{ Effect = "Allow", Principal = { Service = "ecs-tasks.amazonaws.com" }, Action = "sts:AssumeRole" }]
+  })
+}
+
+# ECS Exec channel — the test runner reads/writes the MongoDB sentinel via execute-command.
+resource "aws_iam_role_policy" "task_exec_channel" {
+  name = "${var.name_prefix}-task-exec"
+  role = aws_iam_role.task.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+
+### EBS Volume ###
+
+resource "aws_ebs_volume" "data" {
+  availability_zone = local.az
+  size              = 5
+  type              = "gp3"
+  tags              = { Name = "${var.name_prefix}-data" }
+}
+
+
+### Task Definition ###
+
+resource "aws_ecs_task_definition" "mongo" {
+  family                   = "${var.name_prefix}-mongo"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  volume {
+    name = aws_ebs_volume.data.id
+    docker_volume_configuration {
+      scope         = "shared"
+      autoprovision = true
+      driver        = "polarity-ecs-ebs-plugin"
+      labels        = { Name = aws_ebs_volume.data.id }
+    }
+  }
+
+  container_definitions = jsonencode([{
+    name              = "mongo"
+    image             = var.mongo_image
+    essential         = true
+    memory            = 512
+    memoryReservation = 256
+    linuxParameters   = { initProcessEnabled = true }
+    mountPoints = [{
+      sourceVolume  = aws_ebs_volume.data.id
+      containerPath = "/data/db"
+    }]
+    portMappings = [{ containerPort = 27017, protocol = "tcp" }]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.this.name
+        "awslogs-region"        = var.aws_region
+        "awslogs-stream-prefix" = "mongo"
+      }
+    }
+  }])
+}
+
+
+### ECS Service ###
+
+resource "aws_ecs_service" "mongo" {
+  name                               = "${var.name_prefix}-mongo"
+  cluster                            = aws_ecs_cluster.this.id
+  task_definition                    = aws_ecs_task_definition.mongo.arn
+  desired_count                      = 1
+  launch_type                        = "EC2"
+  enable_execute_command             = true
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = var.deployment_maximum_percent
+
+  network_configuration {
+    subnets         = [aws_subnet.public.id]
+    security_groups = [aws_security_group.instance.id]
+  }
+
+  placement_constraints {
+    type       = "memberOf"
+    expression = "attribute:${local.instance_attr} == true"
+  }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
+}
+
+
+### Outputs ###
+
+output "region" { value = var.aws_region }
+output "cluster_name" { value = aws_ecs_cluster.this.name }
+output "service_name" { value = aws_ecs_service.mongo.name }
+output "volume_id" { value = aws_ebs_volume.data.id }
+output "grant_stop_task" { value = var.grant_stop_task }
+output "deployment_maximum_percent" { value = var.deployment_maximum_percent }

--- a/test/integration/run-tests.sh
+++ b/test/integration/run-tests.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Integration scenarios for polarity-ecs-ebs-plugin. Reads the Terraform outputs of the
+# environment stood up by main.tf and drives the plugin through its failure modes.
+#
+# The data-integrity sentinel is written/read via SSM Run Command on the host that runs
+# the task (docker exec into the mongo container) — headless and reliable, unlike
+# `aws ecs execute-command` which needs a TTY. Force-detach behavior is asserted from the
+# plugin's docker journal on the host (immediate, unlike CloudTrail which lags).
+set -euo pipefail
+
+REGION=$(terraform output -raw region)
+CLUSTER=$(terraform output -raw cluster_name)
+SERVICE=$(terraform output -raw service_name)
+VOLUME=$(terraform output -raw volume_id)
+STOP_TASK=$(terraform output -raw grant_stop_task)
+MAX_PCT=$(terraform output -raw deployment_maximum_percent)
+
+SENTINEL="SENTINEL_$(date +%s)"
+
+log()  { echo "[$(date +%H:%M:%S)] $*"; }
+fail() { echo "ASSERT FAILED: $*" >&2; exit 1; }
+
+wait_stable() {
+  log "waiting for service to stabilize..."
+  aws ecs wait services-stable --cluster "$CLUSTER" --services "$SERVICE" --region "$REGION"
+}
+
+running_task() {
+  aws ecs list-tasks --cluster "$CLUSTER" --service-name "$SERVICE" \
+    --desired-status RUNNING --region "$REGION" --query 'taskArns[0]' --output text
+}
+
+# EC2 instance id running the current task.
+task_instance() {
+  local task ci
+  task=$(running_task)
+  ci=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$task" --region "$REGION" \
+    --query 'tasks[0].containerInstanceArn' --output text)
+  aws ecs describe-container-instances --cluster "$CLUSTER" --container-instances "$ci" \
+    --region "$REGION" --query 'containerInstances[0].ec2InstanceId' --output text
+}
+
+# Run a shell script on a host via SSM and print its stdout. Script is base64-encoded to
+# avoid any quoting issues in the SSM command JSON.
+ssm_run() {
+  local id=$1 script=$2 b64 cmd
+  b64=$(printf '%s' "$script" | base64 | tr -d '\n')
+  cmd=$(aws ssm send-command --instance-ids "$id" --document-name AWS-RunShellScript \
+    --parameters "commands=[\"echo $b64 | base64 -d | sh\"]" \
+    --region "$REGION" --query 'Command.CommandId' --output text)
+  aws ssm wait command-executed --command-id "$cmd" --instance-id "$id" --region "$REGION" >/dev/null 2>&1 || true
+  aws ssm get-command-invocation --command-id "$cmd" --instance-id "$id" \
+    --region "$REGION" --query 'StandardOutputContent' --output text
+}
+
+# docker exec into the mongo container on the task's host to touch the sentinel on the volume.
+MONGO_CID='cid=$(docker ps -q --filter label=com.amazonaws.ecs.container-name=mongo | head -1)'
+write_sentinel() { ssm_run "$(task_instance)" "$MONGO_CID; docker exec \"\$cid\" sh -c 'echo $SENTINEL > /data/db/SENTINEL'" >/dev/null; }
+read_sentinel()  { ssm_run "$(task_instance)" "$MONGO_CID; docker exec \"\$cid\" sh -c 'cat /data/db/SENTINEL 2>/dev/null'" | grep -Eo "${SENTINEL}" | head -1; }
+
+# Times the plugin logged a force detach on a host (from its docker journal).
+force_detach_logs() {
+  ssm_run "$1" "journalctl -u docker --no-pager | grep -c 'Force-detaching' || true"
+}
+
+# Wedge a host's kernel via a sysrq panic (panic=0 makes it hang instead of rebooting).
+# Fire-and-forget: the instance dies mid-command, so we don't wait for the invocation.
+crash_kernel() {
+  aws ssm send-command --instance-ids "$1" --document-name AWS-RunShellScript \
+    --parameters 'commands=["sysctl -w kernel.panic=0; echo 1 > /proc/sys/kernel/sysrq; echo c > /proc/sysrq-trigger"]' \
+    --region "$REGION" --query 'Command.CommandId' --output text >/dev/null 2>&1 || true
+}
+
+# A non-fatal GitHub Actions warning: the plugin recovered the volume, but via an
+# unexpected path for the current kernel state. Keeps the job green, flags it in the UI.
+warn() { echo "::warning::$*"; log "WARN: $*"; }
+
+# lastStatus of a task arn (NONE if missing).
+task_last_status() {
+  [ "$1" = "None" ] && { echo NONE; return; }
+  aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$1" --region "$REGION" \
+    --query 'tasks[0].lastStatus' --output text 2>/dev/null || echo NONE
+}
+
+# All EC2 instance ids currently registered in the cluster.
+all_instances() {
+  local arns
+  arns=$(aws ecs list-container-instances --cluster "$CLUSTER" --region "$REGION" \
+    --query 'containerInstanceArns' --output text)
+  [ -n "$arns" ] && [ "$arns" != "None" ] || return 0
+  aws ecs describe-container-instances --cluster "$CLUSTER" --container-instances $arns \
+    --region "$REGION" --query 'containerInstances[].ec2InstanceId' --output text
+}
+
+# Sum of force-detach log occurrences across all cluster instances.
+total_force() {
+  local sum=0 i
+  for i in $(all_instances); do sum=$((sum + $(force_detach_logs "$i"))); done
+  echo "$sum"
+}
+
+
+### Scenario: baseline ###
+
+log "== baseline =="
+wait_stable
+write_sentinel
+[ "$(read_sentinel)" = "$SENTINEL" ] || fail "sentinel not written/readable"
+log "sentinel ok"
+
+
+### Scenario 1: healthy handover (data survives, no force-detach expected) ###
+# A normal redeploy hands the volume over between healthy instances. Hard invariant:
+# the volume is recovered and the data survives. Expected path: a clean (non-force)
+# detach — a force-detach here would mean a healthy holder failed to release the volume,
+# which is unexpected, so we flag it (warning) without failing.
+
+log "== healthy handover (redeploy, max_pct=$MAX_PCT, stop_task=$STOP_TASK) =="
+aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" --force-new-deployment --region "$REGION" >/dev/null
+wait_stable
+[ "$(read_sentinel)" = "$SENTINEL" ] || fail "data lost across healthy handover"
+[ "$(total_force)" -eq 0 ] && log "handover ok (clean detach)" \
+  || warn "force-detach happened during a healthy handover — a live holder should release the volume cleanly"
+
+
+### Scenario 2: wedged holder (the 2026-07-15 incident) ###
+# On Nitro a non-force detach is an nvme hot-remove that a *live* guest kernel always
+# completes — even with the fs mounted and busy (measured: it detaches in ~3s regardless).
+# The only way it genuinely gets stuck is a holder whose kernel can no longer process the
+# removal. We wedge it with a sysrq panic (mongo still running and holding the volume,
+# exactly as in the incident), then DRAIN it (not deregister) so the old task stays visible
+# to the plugin — this makes the plugin walk its real escalation: StopTask (issued but
+# ineffective, agent is dead) -> non-force detach (times out) -> force-detach.
+#
+# Hard invariant: the volume is recovered on another instance and the data survives.
+# Expected path on a wedged holder: a force-detach. If it somehow recovered without one,
+# that contradicts the measured Nitro behavior — flag it (warning + diagnostics), don't fail.
+
+log "== wedged holder (incident) =="
+HOLDER=$(task_instance)
+HOLDER_CI=$(aws ecs list-container-instances --cluster "$CLUSTER" \
+  --filter "ec2InstanceId == $HOLDER" --region "$REGION" \
+  --query 'containerInstanceArns[0]' --output text)
+
+log "crashing the kernel on $HOLDER (mongo still holds the volume; guest can't release it)"
+crash_kernel "$HOLDER"
+sleep 25  # let the panic land before we drive the reschedule
+
+log "draining $HOLDER so ECS reschedules while the old (unstoppable) task stays visible"
+aws ecs update-container-instances-state --cluster "$CLUSTER" \
+  --container-instances "$HOLDER_CI" --status DRAINING --region "$REGION" >/dev/null
+
+# Wait for the replacement to come up RUNNING on the other instance. We poll the task
+# directly instead of `services-stable`: the wedged task lingers as a zombie and would keep
+# the service from ever reporting stable.
+log "waiting for the replacement task to run on the other instance..."
+NEWHOST=$HOLDER
+for _ in $(seq 1 100); do
+  t=$(running_task)
+  NEWHOST=$(task_instance 2>/dev/null || echo "$HOLDER")
+  [ "$NEWHOST" != "$HOLDER" ] && [ "$NEWHOST" != "None" ] && [ "$(task_last_status "$t")" = "RUNNING" ] && break
+  sleep 15
+done
+{ [ "$NEWHOST" != "$HOLDER" ] && [ "$NEWHOST" != "None" ] && [ "$(task_last_status "$(running_task)")" = "RUNNING" ]; } \
+  || fail "recovery failed: no RUNNING task on another instance — the volume was never recovered from the wedged holder"
+
+[ "$(read_sentinel)" = "$SENTINEL" ] || fail "data lost recovering from the wedged holder"
+log "recovered on $NEWHOST, data intact"
+
+FORCE_COUNT=$(force_detach_logs "$NEWHOST")
+if [ "$FORCE_COUNT" -gt 0 ]; then
+  log "force-detach confirmed ($FORCE_COUNT occurrence(s)) on $NEWHOST — expected path"
+else
+  warn "recovered from a wedged holder WITHOUT a force-detach — unexpected on Nitro; dumping the plugin path"
+  echo "---- $NEWHOST plugin journal ----"
+  ssm_run "$NEWHOST" "journalctl -u docker --no-pager | grep -iE 'detach|attach|available|in-use|Force|Stopping|StopTask' | tail -80"
+fi
+
+log "ALL SCENARIOS PASSED"


### PR DESCRIPTION
On Mount, stop any other task whose container may still be live on the volume (lastStatus RUNNING/DEACTIVATING/STOPPING) and wait for STOPPED before taking it over. The task being mounted is pre-RUNNING so it is never stopped.

Detach escalation: non-force if the holder was stopped cleanly, force if it is unreachable (a non-force detach against a dead instance is accepted by AWS but never completes), terminate the instance as a last resort. Waits use a timeout so they cannot hang.

Wait for the attached block device to be readable before probing/mounting, to fix the first-task failure when the /dev node appears before the kernel has the device online.

Works with both deployment_maximum_percent 100 and 200 (retrocompatible).

Requires ecs:StopTask and ec2:TerminateInstances on the instance role.